### PR TITLE
프로젝트 페이지 사이드바

### DIFF
--- a/frontend/src/components/project/SideBar.jsx
+++ b/frontend/src/components/project/SideBar.jsx
@@ -1,4 +1,6 @@
 import React from "react";
+import styles from "./SideBar.module.css";
+import SideBarItem from "./SideBarItem";
 
 const categories = [
   {
@@ -43,15 +45,15 @@ const categories = [
   },
 ];
 
-export default function SideBar() {
+export default function SideBar({ onClick }) {
   return (
-    <ul>
+    <ul className={styles.category}>
       {categories.map((c, index) => (
-        <li key={index}>
-          <p>{c.category}</p>
+        <li className={styles.list} key={index}>
+          <p className={styles.category__name}>{c.category}</p>
           <ul>
             {c.list.map((item, index) => (
-              <li key={index}>{item}</li>
+              <SideBarItem key={index} item={item} onClick={onClick} />
             ))}
           </ul>
         </li>

--- a/frontend/src/components/project/SideBar.jsx
+++ b/frontend/src/components/project/SideBar.jsx
@@ -1,0 +1,61 @@
+import React from "react";
+
+const categories = [
+  {
+    category: "프론트엔드",
+    list: ["JavaScript", "TypeScript", "React", "Vue", "Svelte", "Nextjs"],
+  },
+  {
+    category: "백엔드",
+    list: [
+      "Java",
+      "Spring",
+      "Nodejs",
+      "Nestjs",
+      "Go",
+      "Kotlin",
+      "Express",
+      "MySQL",
+      "MongoDB",
+      "Python",
+      "Django",
+      "php",
+      "GraphQL",
+      "Firebase",
+    ],
+  },
+  {
+    category: "모바일",
+    list: ["Flutter", "Swift", "Kotlin", "ReactNative", "Unity"],
+  },
+  {
+    category: "기타",
+    list: [
+      "AWS",
+      "Kubernetes",
+      "Docker",
+      "Git",
+      "Figma",
+      "Zeplin",
+      "Jest",
+      "C",
+    ],
+  },
+];
+
+export default function SideBar() {
+  return (
+    <ul>
+      {categories.map((c, index) => (
+        <li key={index}>
+          <p>{c.category}</p>
+          <ul>
+            {c.list.map((item, index) => (
+              <li key={index}>{item}</li>
+            ))}
+          </ul>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/components/project/SideBar.jsx
+++ b/frontend/src/components/project/SideBar.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import styles from "./SideBar.module.css";
-import SideBarItem from "./SideBarItem";
+import SideBarList from "./SideBarList";
 
 const categories = [
   {
@@ -48,15 +48,12 @@ const categories = [
 export default function SideBar({ onClick }) {
   return (
     <ul className={styles.category}>
-      {categories.map((c, index) => (
-        <li className={styles.list} key={index}>
-          <p className={styles.category__name}>{c.category}</p>
-          <ul>
-            {c.list.map((item, index) => (
-              <SideBarItem key={index} item={item} onClick={onClick} />
-            ))}
-          </ul>
-        </li>
+      {categories.map((categoryItems, index) => (
+        <SideBarList
+          key={index}
+          categoryItems={categoryItems}
+          onClick={onClick}
+        />
       ))}
     </ul>
   );

--- a/frontend/src/components/project/SideBar.module.css
+++ b/frontend/src/components/project/SideBar.module.css
@@ -1,0 +1,12 @@
+.category {
+  padding: 2rem 3rem;
+}
+
+.list {
+  margin-bottom: 2rem;
+}
+
+.category__name {
+  font-size: 1.1rem;
+  font-weight: bold;
+}

--- a/frontend/src/components/project/SideBar.module.css
+++ b/frontend/src/components/project/SideBar.module.css
@@ -1,12 +1,3 @@
 .category {
-  padding: 2rem 3rem;
-}
-
-.list {
-  margin-bottom: 2rem;
-}
-
-.category__name {
-  font-size: 1.1rem;
-  font-weight: bold;
+  padding: 2rem;
 }

--- a/frontend/src/components/project/SideBarItem.jsx
+++ b/frontend/src/components/project/SideBarItem.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+import styles from "./SideBarItem.module.css";
+
+export default function SideBarItem({ item, onClick }) {
+  return (
+    <li className={styles.list}>
+      <label htmlFor={item}>{item}</label>
+      <input
+        className={styles.checkbox}
+        onClick={() => onClick(item)}
+        type="checkbox"
+        id={item}
+      />
+    </li>
+  );
+}

--- a/frontend/src/components/project/SideBarItem.jsx
+++ b/frontend/src/components/project/SideBarItem.jsx
@@ -4,7 +4,9 @@ import styles from "./SideBarItem.module.css";
 export default function SideBarItem({ item, onClick }) {
   return (
     <li className={styles.list}>
-      <label htmlFor={item}>{item}</label>
+      <label htmlFor={item} className={styles.label}>
+        {item}
+      </label>
       <input
         className={styles.checkbox}
         onClick={() => onClick(item)}

--- a/frontend/src/components/project/SideBarItem.module.css
+++ b/frontend/src/components/project/SideBarItem.module.css
@@ -1,0 +1,12 @@
+.list {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5rem 1rem 0.5rem 0;
+}
+
+.checkbox {
+  width: 1rem;
+  height: 1rem;
+  margin-left: 2rem;
+}

--- a/frontend/src/components/project/SideBarItem.module.css
+++ b/frontend/src/components/project/SideBarItem.module.css
@@ -2,11 +2,17 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 0.5rem 1rem 0.5rem 0;
+  padding: 0.5rem 0;
+  width: 140px;
+}
+
+.label {
+  flex-grow: 1;
+  cursor: pointer;
 }
 
 .checkbox {
   width: 1rem;
   height: 1rem;
-  margin-left: 2rem;
+  cursor: pointer;
 }

--- a/frontend/src/components/project/SideBarList.jsx
+++ b/frontend/src/components/project/SideBarList.jsx
@@ -1,0 +1,30 @@
+import React, { useState } from "react";
+import styles from "./SideBarList.module.css";
+import SideBarItem from "./SideBarItem";
+import { IoIosArrowUp } from "react-icons/io";
+
+export default function SideBarList({ categoryItems, onClick }) {
+  const [toggle, setToggle] = useState(true);
+  const handleClick = () => {
+    setToggle((prev) => !prev);
+  };
+
+  return (
+    <li className={styles.list}>
+      <p className={styles.category__name}>{categoryItems.category}</p>
+      <IoIosArrowUp
+        className={`${styles.arrow} ${toggle ? "" : styles.hidden}`}
+        onClick={handleClick}
+      />
+      <ul
+        className={`${styles.category__list} ${
+          toggle ? "" : styles.category__hidden
+        }`}
+      >
+        {categoryItems.list.map((item, index) => (
+          <SideBarItem key={index} item={item} onClick={onClick} />
+        ))}
+      </ul>
+    </li>
+  );
+}

--- a/frontend/src/components/project/SideBarList.jsx
+++ b/frontend/src/components/project/SideBarList.jsx
@@ -16,11 +16,7 @@ export default function SideBarList({ categoryItems, onClick }) {
         className={`${styles.arrow} ${toggle ? "" : styles.hidden}`}
         onClick={handleClick}
       />
-      <ul
-        className={`${styles.category__list} ${
-          toggle ? "" : styles.category__hidden
-        }`}
-      >
+      <ul className={toggle ? styles.category__list : styles.category__hidden}>
         {categoryItems.list.map((item, index) => (
           <SideBarItem key={index} item={item} onClick={onClick} />
         ))}

--- a/frontend/src/components/project/SideBarList.module.css
+++ b/frontend/src/components/project/SideBarList.module.css
@@ -15,7 +15,7 @@
   width: 20px;
   height: 20px;
   cursor: pointer;
-  transition: all 0.1s ease-in-out;
+  transition: all 0.4s ease;
 }
 
 .hidden {
@@ -23,9 +23,13 @@
 }
 
 .category__list {
+  max-height: 100vh;
   overflow: hidden;
+  transition: all 0.4s ease;
 }
 
 .category__hidden {
-  height: 0;
+  max-height: 0;
+  overflow: hidden;
+  transition: all 0.4s ease;
 }

--- a/frontend/src/components/project/SideBarList.module.css
+++ b/frontend/src/components/project/SideBarList.module.css
@@ -1,0 +1,31 @@
+.list {
+  position: relative;
+  padding-bottom: 1rem;
+}
+
+.category__name {
+  font-size: 1.1rem;
+  font-weight: bold;
+}
+
+.arrow {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
+  transition: all 0.1s ease-in-out;
+}
+
+.hidden {
+  transform: rotate(180deg);
+}
+
+.category__list {
+  overflow: hidden;
+}
+
+.category__hidden {
+  height: 0;
+}

--- a/frontend/src/pages/Project/Project.jsx
+++ b/frontend/src/pages/Project/Project.jsx
@@ -1,5 +1,11 @@
 import React from "react";
+import SideBar from "../../components/project/SideBar";
 
 export default function Project() {
-  return <div>projects</div>;
+  return (
+    <>
+      <SideBar />
+      projects
+    </>
+  );
 }

--- a/frontend/src/pages/Project/Project.jsx
+++ b/frontend/src/pages/Project/Project.jsx
@@ -15,7 +15,10 @@ export default function Project() {
   return (
     <div className={styles.page}>
       <SideBar onClick={handleCategories} />
-      {categories}
+      <div className={styles.main}>
+        <aside>{categories}</aside>
+        <section>project</section>
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/Project/Project.jsx
+++ b/frontend/src/pages/Project/Project.jsx
@@ -1,11 +1,21 @@
-import React from "react";
+import React, { useState } from "react";
 import SideBar from "../../components/project/SideBar";
+import styles from "./Project.module.css";
 
 export default function Project() {
+  const [categories, setCategories] = useState([]);
+  const handleCategories = (category) => {
+    if (categories.includes(category)) {
+      setCategories((prev) => prev.filter((c) => c !== category));
+    } else {
+      setCategories((prev) => [...prev, category]);
+    }
+  };
+
   return (
-    <>
-      <SideBar />
-      projects
-    </>
+    <div className={styles.page}>
+      <SideBar onClick={handleCategories} />
+      {categories}
+    </div>
   );
 }

--- a/frontend/src/pages/Project/Project.module.css
+++ b/frontend/src/pages/Project/Project.module.css
@@ -1,0 +1,3 @@
+.page {
+  display: flex;
+}

--- a/frontend/src/pages/Project/Project.module.css
+++ b/frontend/src/pages/Project/Project.module.css
@@ -1,3 +1,7 @@
 .page {
   display: flex;
 }
+
+.main {
+  width: 100%;
+}


### PR DESCRIPTION
## ⭐Key Changes
1. 프로젝트 페이지에 사이드바를 추가했습니다.
2. 사이드바에 토글 기능을 구현했습니다.
3. react의 state로 선택한 언어를 저장하게 만들었습니다.

## To Reviewers
사이드바에서 각 메뉴 리스트(프론트엔드의 javascript, react, ...)를 토글할 때 바로 사라지고 나타나게 했는데, 부드럽게 하는게 좋다고 생각되면 말해주세요.

## Next move
프로젝트 페이지의 상단부분
